### PR TITLE
fix: ensure KeyData is never null on first run

### DIFF
--- a/WhatAmIHearing/AppSettings.cs
+++ b/WhatAmIHearing/AppSettings.cs
@@ -78,7 +78,7 @@ internal sealed partial class AppSettings : ObservableObject
    private double _historyHeight = 80;
 
    [ObservableProperty]
-   private ApiKeyData _keyData;
+   private ApiKeyData _keyData = new();
 }
 
 internal sealed partial class ApiKeyData : ObservableObject


### PR DESCRIPTION
## Issue 
On latest version if no config.json (or legacy ShazamApiKey.json) exists, the app creates initial AppSettings object with `"KeyData":null`, which stops any attempts to read or write api key in memory or config file, will cause the app to crash the moment you send song detection request.
This bug will also cause API Key placeholder TextBlock to always be shown, overlaying on top of the text/api key under it.

Fixed simply by initializing the field in constructor.